### PR TITLE
Mb add fusion catcher

### DIFF
--- a/FusionCatcher/latest/Dockerfile
+++ b/FusionCatcher/latest/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:14.04
+
+MAINTAINER daniel.nicorici@gmail.com
+
+LABEL Description="This image is used to run FusionCatcher" Version="1.00"
+
+RUN apt-get -y clean \
+    && apt-get -y update \
+    && apt-get -y install \
+    automake \
+    build-essential \
+    bzip2 \
+    cmake \
+    curl \
+    g++ \
+    gawk \
+    gcc \
+    gzip  \
+    libc6-dev \
+    libncurses5-dev \
+    libtbb2 \
+    libtbb-dev \
+    make \
+    parallel \
+    pigz \
+    python \
+    python-dev \
+    python-biopython \
+    python-numpy \
+    python-openpyxl \
+    python-xlrd \
+    tar \
+    unzip \
+    wget \
+    zip \
+    zlib1g \
+    zlib1g-dev \
+    zlibc \
+    default-jdk \
+    && apt-get -y clean
+
+WORKDIR /opt
+
+######################
+## INSTALLATION
+######################
+
+RUN wget --no-check-certificate http://sf.net/projects/fusioncatcher/files/bootstrap.py -O bootstrap.py \
+    && python bootstrap.py -t -y -i /opt/fusioncatcher/v1.00/

--- a/arriba/latest/Dockerfile
+++ b/arriba/latest/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:bionic
+MAINTAINER Sebastian Uhrig @ DKFZ
+
+# install dependencies
+RUN export DEBIAN_FRONTEND=noninteractive && \
+apt-get update -y && \
+apt-get install -y samtools r-base rna-star wget libcurl4-openssl-dev libxml2-dev && \
+Rscript -e 'install.packages("circlize", repos="http://cran.r-project.org"); source("https://bioconductor.org/biocLite.R"); biocLite(c("GenomicRanges", "GenomicAlignments"))'
+
+# install arriba
+RUN URL=$(wget -q -O - https://api.github.com/repos/suhrig/arriba/releases/latest | sed -n -e 's/.*"browser_download_url":\s*"\([^"]*\)".*/\1/p') && \
+wget -q -O - "$URL" | tar -xzf -
+
+# make wrapper script for download_references.sh
+RUN echo '#!/bin/bash\n\
+cd /references\n\
+/arriba*/download_references.sh $1 $2 && \\\n\
+cp /arriba*/database/*${1%+*}* /references' > /usr/local/bin/download_references.sh && \
+chmod a+x /usr/local/bin/download_references.sh
+
+# make wrapper script for run_arriba.sh
+RUN echo '#!/bin/bash\n\
+cd /output\n\
+/arriba*/run_arriba.sh /references/STAR_index_* /references/*.gtf /references/*.fa /references/blacklist_*.tsv.gz /read1.fastq.gz /read2.fastq.gz ${1-8}' > /usr/local/bin/arriba.sh && \
+chmod a+x /usr/local/bin/arriba.sh
+
+# make wrapper script for draw_fusions.R
+RUN echo '#!/bin/bash\n\
+Rscript /arriba*/draw_fusions.R --annotation=$(ls /references/*.gtf) --fusions=/fusions.tsv --output=/output/fusions.pdf --proteinDomains=$(ls /references/protein_domains_*.gff3) --alignments=/Aligned.sortedByCoord.out.bam --cytobands=$(ls /references/cytobands_*.tsv)' > /usr/local/bin/draw_fusions.sh && \
+chmod a+x /usr/local/bin/draw_fusions.sh

--- a/pizzly/latest/Dockerfile
+++ b/pizzly/latest/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:18.04
 MAINTAINER Miguel Brown (brownm28@email.chop.edu)
 
-RUN apt update && apt install -y git cmake g++ libz-dev; \
+ENV PIZZLY_VERSION=0.37.3
+
+RUN apt update && apt install -y git cmake g++ libz-dev python3; \
 git clone https://github.com/pmelsted/pizzly.git; \
 cd pizzly; \
 mkdir build && cd build && cmake .. && make && make install; \

--- a/pizzly/latest/Dockerfile
+++ b/pizzly/latest/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+MAINTAINER Miguel Brown (brownm28@email.chop.edu)
+
+RUN apt update && apt install -y git cmake g++ libz-dev; \
+git clone https://github.com/pmelsted/pizzly.git; \
+cd pizzly; \
+mkdir build && cd build && cmake .. && make && make install; \
+apt remove -y git && apt autoclean -y  && apt autoremove -y


### PR DESCRIPTION
Added docker files for fusionCatcher, arriba and pizzly.  Dockers for arriba and fusionCatcher mostly unchanged from developers git dockerfile, just created here to have an auto build.  made pizzzly docker since it was missing flatten script on sbg version.