### PR TITLE
🔧 Fixed source file bug

### DIFF
--- a/gatk/3.8_ubuntu/Dockerfile
+++ b/gatk/3.8_ubuntu/Dockerfile
@@ -1,9 +1,13 @@
 FROM ubuntu:18.04
-MAINTAINER Miguel Brown (brownm28@email.chop.edu)
+LABEL maintainer="Miguel Brown (brownm28@email.chop.edu)"
 
 ENV GATK3_VERSION 3.8
 
-RUN apt update && apt install -y openjdk-8-jdk curl tabix; \
-curl https://software.broadinstitute.org/gatk/download/auth\?package\=GATK | tar xjv; \
-mv GenomeAnalysisTK-3.8-*/GenomeAnalysisTK.jar . && rm -rf GenomeAnalysisTK-3.8-*/; \
-apt remove -y curl
+RUN apt update && apt install -y openjdk-8-jdk tabix curl gnupg
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+&& curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+&& apt update && apt install -y google-cloud-sdk
+RUN gsutil cp gs://gatk-software/package-archive/gatk/GenomeAnalysisTK-${GATK3_VERSION}-0-ge9d806836.tar.bz2 . \
+&& tar -xjf GenomeAnalysisTK-${GATK3_VERSION}-0-ge9d806836.tar.bz2 && mv GenomeAnalysisTK-${GATK3_VERSION}-0-ge9d806836/GenomeAnalysisTK.jar . \
+&& rm -rf GenomeAnalysisTK-${GATK3_VERSION}-*/ GenomeAnalysisTK-${GATK3_VERSION}-0-ge9d806836.tar.bz2 \
+&& apt remove -y curl google-cloud-sdk


### PR DESCRIPTION
Broad recently moved some of their files to google cloud, including source for gatk 3.8. this should fix the docker file and image.