### PR TITLE
🐛🔖 adding v0.1.8 annoFuse and bug fix

### DIFF
--- a/annoFuse/0.1.8/annoFusePerSample.R
+++ b/annoFuse/0.1.8/annoFusePerSample.R
@@ -1,0 +1,119 @@
+install.packages("/opt/formatFusionCalls/annoFuse_0.1.8.tar.gz",repos = NULL)
+library("annoFuse")
+
+suppressPackageStartupMessages(library("readr"))
+suppressPackageStartupMessages(library("tidyverse"))
+suppressPackageStartupMessages(library("reshape2"))
+suppressPackageStartupMessages(library("optparse"))
+
+option_list <- list(
+  make_option(c("-a", "--fusionfileArriba"),type="character",
+              help="Formatted fusion calls from arriba"),
+  make_option(c("-s", "--fusionfileStarFusion"),type="character",
+              help="Formatted fusion calls from starfusion"),
+  make_option(c("-e", "--expressionFile"),type="character",
+              help="RSEM file for sample"),
+  make_option(c("-t", "--tumorID"),type="character",
+              help="Sample name to rename column in RSEM FPKM column"),
+  make_option(c("-o","--outputfile"),type="character",
+              help="Formatted and filtered fusion calls from [STARfusion | Arriba] (.TSV)")
+)
+
+#read in caller results
+opt <- parse_args(OptionParser(option_list=option_list))
+Arribainputfile <- opt$fusionfileArriba
+STARFusioninputfile <- opt$fusionfileStarFusion
+expressionFile<-opt$expressionFile
+tumor_id<-opt$tumorID
+outputfile <- opt$outputfile
+
+# read files
+STARFusioninputfile<-read_tsv(STARFusioninputfile)
+Arribainputfile<-read_tsv(Arribainputfile)
+
+# if StarFusion and Arriba files empty execution stops
+if(is_empty(STARFusioninputfile$FusionName) & is_empty(Arribainputfile$"gene1--gene2")){
+stop("StarFusion and Arriba files empty")
+  }
+
+# if StarFusion and Arriba files are not empty
+if(!is_empty(STARFusioninputfile$FusionName) & !is_empty(Arribainputfile$"gene1--gene2")){
+colnames(Arribainputfile)[27]<-"annots"
+
+# To have a general column with unique IDs associated with each sample
+STARFusioninputfile$Sample <- STARFusioninputfile$tumor_id
+Arribainputfile$Sample <- Arribainputfile$tumor_id
+Arribainputfile$Caller <- "Arriba"
+STARFusioninputfile$Caller <- "StarFusion"
+
+# standardized fusion calls
+standardizedSTARFusion<-fusion_standardization(fusion_calls = STARFusioninputfile,caller = "STARFUSION")
+standardizedArriba<-fusion_standardization(fusion_calls = Arribainputfile,caller = "ARRIBA")
+
+#merge standardized fusion calls
+standardFusioncalls<-rbind(standardizedSTARFusion,standardizedArriba) %>% as.data.frame()
+}
+
+# if StarFusion file is empty only run standardization for Arriba calls
+if(is_empty(STARFusioninputfile$FusionName) & !is_empty(Arribainputfile$"gene1--gene2")){
+  warning(paste("No fusion calls in StarFusion : ",opt$fusionfileStarFusion))
+  
+  colnames(Arribainputfile)[27]<-"annots"
+  # To have a general column with unique IDs associated with each sample
+  Arribainputfile$Sample <- Arribainputfile$tumor_id
+  Arribainputfile$Caller <- "Arriba"
+  
+  # standardized fusion calls
+  standardizedArriba<-fusion_standardization(fusion_calls = Arribainputfile,caller = "ARRIBA")
+  
+  # standardized fusion calls
+  standardFusioncalls<-standardizedArriba %>% as.data.frame()
+}
+
+# if Arriba file is empty only run standardization for StarFusion calls
+if(!is_empty(STARFusioninputfile$FusionName) & is_empty(Arribainputfile$"gene1--gene2")){
+  warning(paste("No fusion calls in StarFusion : ",opt$fusionfileStarFusion))
+  
+  # To have a general column with unique IDs associated with each sample
+  STARFusioninputfile$Sample <- STARFusioninputfile$tumor_id
+  STARFusioninputfile$Caller <- "StarFusion"
+  
+  # standardized fusion calls
+  standardizedSTARFusion<-fusion_standardization(fusion_calls = STARFusioninputfile,caller = "STARFUSION")
+  
+  # standardized fusion calls
+  standardFusioncalls<-standardizedSTARFusion %>% as.data.frame()
+}
+
+
+
+
+# General fusion QC for read support and red flags
+fusionQCFiltered<-fusion_filtering_QC(standardFusioncalls=standardFusioncalls,readingFrameFilter="in-frame|frameshift|other",artifactFilter="GTEx_Recurrent|DGD_PARALOGS|Normal|BodyMap|ConjoinG",junctionReadCountFilter=1,spanningFragCountFilter=10,readthroughFilter=FALSE)
+
+expressionMatrix<-read_tsv(expressionFile)
+
+# split gene id and symbol
+expressionMatrix <- expressionMatrix %>% 
+  dplyr::mutate(gene_id = str_replace(gene_id, "_PAR_Y_", "_")) 
+
+
+expressionMatrix <- cbind(expressionMatrix, colsplit(expressionMatrix$gene_id, pattern = '_', names = c("EnsembleID","GeneSymbol")))
+
+
+# collapse to matrix of HUGO symbols x Sample identifiers
+# take max expression per row and use the max value for duplicated gene symbols
+expressionMatrix.collapsed <-expressionMatrix  %>% 
+  arrange(desc(FPKM)) %>% # arrange decreasing by FPKM
+  distinct(GeneSymbol, .keep_all = TRUE) %>% # keep the ones with greatest FPKM value. If ties occur, keep the first occurencce
+  unique() %>%
+  remove_rownames()  %>%
+  dplyr::select(EnsembleID,GeneSymbol,FPKM,gene_id)
+
+# rename columns
+colnames(expressionMatrix.collapsed)[3]<-tumor_id
+
+expressionFiltered<-expressionFilterFusion(standardFusioncalls = fusionQCFiltered,expressionFilter = 1,expressionMatrix = expressionMatrix.collapsed)
+
+# write to outputfile
+write.table(expressionFiltered,outputfile,sep="\t",quote=FALSE,row.names = FALSE)

--- a/annoFuse/0.1.8/dockerfile
+++ b/annoFuse/0.1.8/dockerfile
@@ -1,0 +1,21 @@
+FROM rocker/tidyverse:3.5.1
+MAINTAINER gaonkark@chop.email.edu
+WORKDIR /rocker-build/
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+RUN apt-get install dialog apt-utils -y
+
+RUN R -e "install.packages('optparse', dependencies = TRUE)"
+
+RUN R -e "BiocManager::install(c('EnsDb.Hsapiens.v86', 'ensembldb','ggthemes','qdapRegex'))"
+
+WORKDIR /opt/formatFusionCalls
+
+RUN wget -O annoFuse_0.1.8.tar.gz "https://github.com/d3b-center/annoFuse/archive/v0.1.8.tar.gz"
+
+RUN R -e "install.packages('ggpubr', dependencies = TRUE)" 
+
+#add scripts
+ADD formatFusionCalls.R /rocker-build/formatFusionCalls.R
+ADD annoFusePerSample.R /rocker-build/annoFusePerSample.R

--- a/annoFuse/0.1.8/formatFusionCalls.R
+++ b/annoFuse/0.1.8/formatFusionCalls.R
@@ -1,0 +1,40 @@
+suppressPackageStartupMessages(library("readr"))
+suppressPackageStartupMessages(library("dplyr"))
+suppressPackageStartupMessages(library("optparse"))
+
+
+option_list <- list(
+  make_option(c("-f", "--fusionfile"),type="character",
+              help="Fusion calls from [STARfusion | Arriba]"),
+  make_option(c("-c", "--caller"), type="character",
+              help="starfusion|arriba"),
+  make_option(c("-t", "--tumorid"), type="character",
+              help="KF tumor id"),
+  make_option(c("-o","--outputfile"),type="character",
+              help="Formatted fusion calls from [STARfusion | Arriba] (.TSV)")
+)
+
+# Get command line options, if help option encountered print help and exit,
+opt <- parse_args(OptionParser(option_list=option_list))
+inputfile <- opt$fusionfile
+caller <- opt$caller
+tumorid <- opt$tumorid
+outputfile <- opt$outputfile
+
+
+
+if (caller=="starfusion"){
+  df<-read_tsv(inputfile)
+  colnames(df)[colnames(df) == "#FusionName"]<-"FusionName"
+  df$tumor_id<-rep(tumorid,nrow(df))
+}
+
+if (caller=="arriba"){
+  df<-read_tsv(inputfile,col_types = readr::cols(breakpoint1 = readr::col_character(),breakpoint2 = readr::col_character()))
+  colnames(df)[colnames(df) == "#gene1"]<-"gene1"    
+  df$tumor_id<-rep(tumorid,nrow(df))
+  df$`gene1--gene2`<-paste(df$gene1,df$gene2,sep="--")
+}
+
+# write to output file
+write.table(df,outputfile,sep="\t",quote=FALSE,row.names = FALSE)


### PR DESCRIPTION
Description : 
Updates the docker to download specific release binary files for annoFuse v0.1.8 https://github.com/d3b-center/annoFuse/releases instead of building from master as I did in the existing dockerfile being used

Note:
- Docker image is being tagged with version gaonkark/annofuse:v0.1.8 will need to be updated in cwl
- Also while finding a file to test run I found this run
https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-dypmehhf-04/tasks/8bb489d4-d272-437c-aa2c-85c5c7d62682/ where for some reason the parser package (tidyverse) I'm using to read files detects the LeftBreakpoint and RightBreakpoint as date datatype which causes the "NA" to come up in LeftBreakpoint and RightBreakpoint columns in output files if it has very few calls in input files to detect from causing only a warning:
https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-dypmehhf-04/tasks/8bb489d4-d272-437c-aa2c-85c5c7d62682/stats/
I've fixed it to read these breakpoint columns as character data type in this docker image as well.

**Tested** with the both arriba and starfusion files, only arriba file and empty starfusion files and also https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-dypmehhf-04/files/5cf7dfdae4b0359d5582de01/ where the datatype detection issues doesn't occur now. 
