### PR TITLE
:whale: create dockerfile for STAR 2.7.5a

### DIFF
--- a/star/2.7.5a/Dockerfile
+++ b/star/2.7.5a/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04 AS build-env
+MAINTAINER Alex Sickler (sicklera@email.chop.edu)
+
+
+ENV STAR_VERSION 2.7.5a
+
+RUN apt-get update; \ 
+apt-get install --yes wget; \
+apt-get clean; \
+cd /usr/local && wget https://github.com/alexdobin/STAR/archive/${STAR_VERSION}.tar.gz; \
+tar -zxf ${STAR_VERSION}.tar.gz; \
+mv STAR-${STAR_VERSION}/bin/Linux_x86_64_static/STAR /usr/bin/STAR; \


### PR DESCRIPTION
Dockerfile for STAR version 2.7.5a. This version of STAR has updates specifically for single cell RNA.

Part of the single cell RNA ticket for SMART-Seq2: https://app.zenhub.com/workspaces/d3b-bfx-5cdd720eed0dce4209e0b8a5/issues/d3b-center/bixu-tracker/690
