### PR TITLE
Change CircleCI config to run monthly not every minute on the 1st

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ workflows:
   monthly:
     triggers:
     - schedule:
-        cron: '* * 1 * *'
+        cron: '57 0 1 * *'
         filters:
           branches:
             only:


### PR DESCRIPTION
Hello from CircleCI!

We noticed you're exhausting your concurrency limit on the first of the month by [running every minute](https://crontab.guru/#*_*_1_*_*).

Hope this helps!