### PR TITLE
✨ updated version to 0.90.0

### DIFF
--- a/annoFuse/0.90.0/Dockerfile
+++ b/annoFuse/0.90.0/Dockerfile
@@ -1,0 +1,19 @@
+FROM rocker/tidyverse:3.5.1
+WORKDIR /rocker-build/
+
+RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
+
+RUN apt-get install dialog apt-utils -y
+
+RUN R -e "install.packages('optparse', dependencies = TRUE)"
+
+RUN R -e "BiocManager::install(c('EnsDb.Hsapiens.v86', 'ensembldb','ggthemes','qdapRegex','shinyBS', 'shinydashboard', 'shinycssloaders', 'rintrojs', 'shinythemes', 'DT','tidyverse'))"
+
+WORKDIR /opt/formatFusionCalls
+
+RUN wget -O annoFuse_0.90.0.tar.gz "https://github.com/d3b-center/annoFuse/archive/v0.90.0.tar.gz"
+
+RUN R -e "install.packages('ggpubr', dependencies = TRUE)" 
+
+ADD formatFusionCalls.R /rocker-build/formatFusionCalls.R
+ADD annoFusePerSample.R /rocker-build/annoFusePerSample.R

--- a/annoFuse/0.90.0/annoFusePerSample.R
+++ b/annoFuse/0.90.0/annoFusePerSample.R
@@ -1,0 +1,51 @@
+install.packages("/opt/formatFusionCalls/annoFuse_0.90.0.tar.gz",repos = NULL)
+library("annoFuse")
+
+suppressPackageStartupMessages(library("readr"))
+suppressPackageStartupMessages(library("tidyverse"))
+suppressPackageStartupMessages(library("reshape2"))
+suppressPackageStartupMessages(library("optparse"))
+
+option_list <- list(
+  make_option(c("-a", "--fusionfileArriba"),type="character",
+              help="Formatted fusion calls from arriba"),
+  make_option(c("-s", "--fusionfileStarFusion"),type="character",
+              help="Formatted fusion calls from starfusion"),
+  make_option(c("-e", "--expressionFile"),type="character",
+              help="RSEM file for sample"),
+  make_option(c("-t", "--tumorID"),type="character",
+              help="Sample name to rename column in RSEM FPKM column"),
+  make_option(c("-o","--outputfile"),type="character",
+              help="Formatted and filtered fusion calls from [STARfusion | Arriba] (.TSV)")
+)
+
+#read in caller results
+opt <- parse_args(OptionParser(option_list=option_list))
+Arribainputfile <- opt$fusionfileArriba
+STARFusioninputfile <- opt$fusionfileStarFusion
+expressionFile<-opt$expressionFile
+tumorID<-opt$tumorID
+outputfile <- opt$outputfile
+
+standardFusioncalls <- annoFuse::annoFuse_single_sample(
+   # Example files are provided in extdata, at-least 1 fusionfile is required along 
+   # with its rsem expression file
+   fusionfileArriba = Arribainputfile,
+   fusionfileStarFusion = STARFusioninputfile,
+   expressionFile = expressionFile,
+   tumorID = tumorID,
+   # multiple read flag values for filtering using FusionAnnotator values
+   artifactFilter = "GTEx_Recurrent|DGD_PARALOGS|Normal|BodyMap",
+   # keep all in-frame , frameshift and other types of Fusion_Type
+   readingFrameFilter = "in-frame|frameshift|other",
+   # keep all fusions with atleast 1 junction read support
+   junctionReadCountFilter = 1,
+   # keep only fusions where spanningFragCount-junctionReadCountFilter less than equal to 100
+   spanningFragCountFilter = 100,
+   # filter read throughs
+   readthroughFilter = FALSE
+)
+
+
+# write to outputfile
+write.table(standardFusioncalls,outputfile,sep="\t",quote=FALSE,row.names = FALSE)

--- a/annoFuse/0.90.0/formatFusionCalls.R
+++ b/annoFuse/0.90.0/formatFusionCalls.R
@@ -1,0 +1,36 @@
+suppressPackageStartupMessages(library("readr"))
+suppressPackageStartupMessages(library("dplyr"))
+suppressPackageStartupMessages(library("optparse"))
+
+
+option_list <- list(
+  make_option(c("-f", "--fusionfile"),type="character",
+              help="Fusion calls from [STARfusion | Arriba]"),
+  make_option(c("-c", "--caller"), type="character",
+              help="starfusion|arriba"),
+  make_option(c("-t", "--tumorid"), type="character",
+              help="KF tumor id"),
+  make_option(c("-o","--outputfile"),type="character",
+              help="Formatted fusion calls from [STARfusion | Arriba] (.TSV)")
+)
+
+# Get command line options, if help option encountered print help and exit,
+opt <- parse_args(OptionParser(option_list=option_list))
+inputfile <- opt$fusionfile
+caller <- opt$caller
+tumorid <- opt$tumorid
+outputfile <- opt$outputfile
+
+
+
+if (caller=="starfusion"){
+  df<-read_tsv(inputfile)
+}
+
+if (caller=="arriba"){
+  df<-read_tsv(inputfile,col_types = readr::cols(breakpoint1 = readr::col_character(),breakpoint2 = readr::col_character()))
+  df$`gene1--gene2`<-paste(df$`#gene1`,df$gene2,sep="--")
+}
+
+# write to output file
+write.table(df,outputfile,sep="\t",quote=FALSE,row.names = FALSE)


### PR DESCRIPTION
## Description of changes 

annoFuse latest release 0.90.0 updates the following:

- SpanningDelta cutoff is now default to 100 , details discussed in https://github.com/d3b-center/bixtools/pull/74#discussion_r487225261 we feel the updated cutoff will provide better results as was seen with TCGA fusion calls
- ConJoinG annotation filtering is removed since we have found out that this annotation is helpful to capture meaningful fusion calls and infact might not be artifact as previous suggested by FusionAnnotator 
- Fixes occasional edge issues of reading arriba breakpoint columns incorrectly as date
- Adds `Sample` column through the function in annoFuse instead of formatting step. 

## Requests for Bix-Dev team to update in app

- Only annoFuse docker needs to be updated, please keep docker for FusionAnnotator the same
- The col_num param needs to be updated to 24 while running the kfdrc-annofuse-wf  app
<img width="459" alt="Screen Shot 2020-09-22 at 1 23 11 PM" src="https://user-images.githubusercontent.com/34580719/93915973-d120a580-fcd6-11ea-8e1b-e160181046bf.png">

Please let me know if you have any questions