### PR TITLE
☁️ get GenomeAnalysisTK from google cloud

### DIFF
--- a/gatk/4.beta.1-3.5/Dockerfile
+++ b/gatk/4.beta.1-3.5/Dockerfile
@@ -4,10 +4,11 @@ MAINTAINER Yuankun Zhu (zhuy@email.chop.edu)
 ENV GATK4_VERSION 4.beta.1
 ENV GATK_ARCHIVE_VERSION 3.5-0-g36282e4
 
-RUN apk add --update --no-cache openjdk8-jre python2 wget curl; \
+RUN apk add --update --no-cache openjdk8-jre python2 wget curl bash; \
 wget https://github.com/broadinstitute/gatk/releases/download/${GATK4_VERSION}/gatk-${GATK4_VERSION}.zip; \
 unzip gatk-${GATK4_VERSION}.zip; \
 mv gatk-${GATK4_VERSION}/gatk-* . && rm -rf gatk-${GATK4_VERSION}*; \
-curl https://software.broadinstitute.org/gatk/download/auth\?package\=GATK-archive\&version\=${GATK_ARCHIVE_VERSION} \
-| tar xjv && rm -rf resources/; \
+curl https://sdk.cloud.google.com > install.sh; bash install.sh --disable-prompts && rm install.sh; \
+export PATH=$PATH:/root/google-cloud-sdk/bin; \
+gsutil cp gs://gatk-software/package-archive/gatk/GenomeAnalysisTK-${GATK_ARCHIVE_VERSION}.tar.bz2 - | tar xjv && rm -rf resources/; \
 apk del wget curl

--- a/gatk/4.beta.1-3.5/Dockerfile
+++ b/gatk/4.beta.1-3.5/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
-MAINTAINER Yuankun Zhu (zhuy@email.chop.edu)
+LABEL maintainer="Yuankun Zhu (zhuy@email.chop.edu)"
 
 ENV GATK4_VERSION 4.beta.1
 ENV GATK_ARCHIVE_VERSION 3.5-0-g36282e4


### PR DESCRIPTION
Closes https://github.com/d3b-center/bixu-tracker/issues/847

Ended up having to install the google-cloud-sdk to get this file as the https file in the ticket had protections and could not be downloaded with curl or wget. 

Test with the new docker: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/62b584be-54ad-4280-aa2b-b55dce5d1b95/