### PR TITLE
⭕️ publish on merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,6 +396,14 @@ workflows:
         path: VEP/r98/
         docker-context: VEP/r98/
     - docker/publish:
+        name: VEP_r93.7_monthly
+        deploy: false
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r93.7
+        path: VEP/r93.7/
+        docker-context: VEP/r93.7/
+    - docker/publish:
         name: VEP_r93_v2_monthly
         deploy: false
         registry: pgc-images.sbgenomics.com
@@ -1267,6 +1275,18 @@ workflows:
             pattern: VEP/r98/Dockerfile
     - docker/publish:
         context: dockerhub-vars
+        name: VEP_r93.7_diff
+        deploy: false
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r93.7
+        path: VEP/r93.7/
+        docker-context: VEP/r93.7/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r93.7/Dockerfile
+    - docker/publish:
+        context: dockerhub-vars
         name: VEP_r93_v2_diff
         deploy: false
         registry: pgc-images.sbgenomics.com
@@ -1865,3 +1885,1535 @@ workflows:
         before_build:
         - run_if_modified:
             pattern: freebayes/v1.3.2/Dockerfile
+  merge:
+    jobs:
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: verifybamid_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/verifybamid
+        tag: latest
+        path: verifybamid/latest/
+        docker-context: verifybamid/latest/
+        before_build:
+        - run_if_modified:
+            pattern: verifybamid/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: verifybamid_1.0.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/verifybamid
+        tag: 1.0.1
+        path: verifybamid/1.0.1/
+        docker-context: verifybamid/1.0.1/
+        before_build:
+        - run_if_modified:
+            pattern: verifybamid/1.0.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: verifybamid_1.0.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/verifybamid
+        tag: 1.0.2
+        path: verifybamid/1.0.2/
+        docker-context: verifybamid/1.0.2/
+        before_build:
+        - run_if_modified:
+            pattern: verifybamid/1.0.2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: arriba_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/arriba
+        tag: latest
+        path: arriba/latest/
+        docker-context: arriba/latest/
+        before_build:
+        - run_if_modified:
+            pattern: arriba/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: arriba_1.0.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/arriba
+        tag: 1.0.1
+        path: arriba/1.0.1/
+        docker-context: arriba/1.0.1/
+        before_build:
+        - run_if_modified:
+            pattern: arriba/1.0.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: arriba_1.1.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/arriba
+        tag: 1.1.0
+        path: arriba/1.1.0/
+        docker-context: arriba/1.1.0/
+        before_build:
+        - run_if_modified:
+            pattern: arriba/1.1.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_2.14.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: 2.14.0
+        path: picard/2.14.0/
+        docker-context: picard/2.14.0/
+        before_build:
+        - run_if_modified:
+            pattern: picard/2.14.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: latest
+        path: picard/latest/
+        docker-context: picard/latest/
+        before_build:
+        - run_if_modified:
+            pattern: picard/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_2.8.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: 2.8.3
+        path: picard/2.8.3/
+        docker-context: picard/2.8.3/
+        before_build:
+        - run_if_modified:
+            pattern: picard/2.8.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_2.18.9_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: 2.18.9
+        path: picard/2.18.9/
+        docker-context: picard/2.18.9/
+        before_build:
+        - run_if_modified:
+            pattern: picard/2.18.9/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_2.17.4_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: 2.17.4
+        path: picard/2.17.4/
+        docker-context: picard/2.17.4/
+        before_build:
+        - run_if_modified:
+            pattern: picard/2.17.4/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard_2.15.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard
+        tag: 2.15.0
+        path: picard/2.15.0/
+        docker-context: picard/2.15.0/
+        before_build:
+        - run_if_modified:
+            pattern: picard/2.15.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: lumpy-sv_0.3.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/lumpy-sv
+        tag: 0.3.0
+        path: lumpy-sv/0.3.0/
+        docker-context: lumpy-sv/0.3.0/
+        before_build:
+        - run_if_modified:
+            pattern: lumpy-sv/0.3.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: lumpy-sv_0.2.13_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/lumpy-sv
+        tag: 0.2.13
+        path: lumpy-sv/0.2.13/
+        docker-context: lumpy-sv/0.2.13/
+        before_build:
+        - run_if_modified:
+            pattern: lumpy-sv/0.2.13/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: zumis_2.9.4_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/zumis
+        tag: 2.9.4
+        path: zumis/2.9.4/
+        docker-context: zumis/2.9.4/
+        before_build:
+        - run_if_modified:
+            pattern: zumis/2.9.4/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: SVTyper_0.7.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/svtyper
+        tag: 0.7.1
+        path: SVTyper/0.7.1/
+        docker-context: SVTyper/0.7.1/
+        before_build:
+        - run_if_modified:
+            pattern: SVTyper/0.7.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: cutadapt_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/cutadapt
+        tag: latest
+        path: cutadapt/latest/
+        docker-context: cutadapt/latest/
+        before_build:
+        - run_if_modified:
+            pattern: cutadapt/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VarDictJava_fp_filter_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vardictjava
+        tag: fp_filter
+        path: VarDictJava/fp_filter/
+        docker-context: VarDictJava/fp_filter/
+        before_build:
+        - run_if_modified:
+            pattern: VarDictJava/fp_filter/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VarDictJava_1.5.8_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vardictjava
+        tag: 1.5.8
+        path: VarDictJava/1.5.8/
+        docker-context: VarDictJava/1.5.8/
+        before_build:
+        - run_if_modified:
+            pattern: VarDictJava/1.5.8/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa-picard_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa-picard
+        tag: latest
+        path: bwa-picard/latest/
+        docker-context: bwa-picard/latest/
+        before_build:
+        - run_if_modified:
+            pattern: bwa-picard/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa-picard_broad_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa-picard
+        tag: broad
+        path: bwa-picard/broad/
+        docker-context: bwa-picard/broad/
+        before_build:
+        - run_if_modified:
+            pattern: bwa-picard/broad/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: python_2.7.13_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/python
+        tag: 2.7.13
+        path: python/2.7.13/
+        docker-context: python/2.7.13/
+        before_build:
+        - run_if_modified:
+            pattern: python/2.7.13/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: smoove_0.2.5_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/smoove
+        tag: 0.2.5
+        path: smoove/0.2.5/
+        docker-context: smoove/0.2.5/
+        before_build:
+        - run_if_modified:
+            pattern: smoove/0.2.5/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: cellranger_3.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/cellranger
+        tag: '3.1'
+        path: cellranger/3.1/
+        docker-context: cellranger/3.1/
+        before_build:
+        - run_if_modified:
+            pattern: cellranger/3.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bcbio_variation_recall-0.2.4_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bcbio
+        tag: variation_recall-0.2.4
+        path: bcbio/variation_recall-0.2.4/
+        docker-context: bcbio/variation_recall-0.2.4/
+        before_build:
+        - run_if_modified:
+            pattern: bcbio/variation_recall-0.2.4/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa-bundle_0.1.17_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa-bundle
+        tag: 0.1.17
+        path: bwa-bundle/0.1.17/
+        docker-context: bwa-bundle/0.1.17/
+        before_build:
+        - run_if_modified:
+            pattern: bwa-bundle/0.1.17/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk-picard_4.beta.1-2.8.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk-picard
+        tag: 4.beta.1-2.8.3
+        path: gatk-picard/4.beta.1-2.8.3/
+        docker-context: gatk-picard/4.beta.1-2.8.3/
+        before_build:
+        - run_if_modified:
+            pattern: gatk-picard/4.beta.1-2.8.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk-picard_4.0.1.2-2.8.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk-picard
+        tag: 4.0.1.2-2.8.3
+        path: gatk-picard/4.0.1.2-2.8.3/
+        docker-context: gatk-picard/4.0.1.2-2.8.3/
+        before_build:
+        - run_if_modified:
+            pattern: gatk-picard/4.0.1.2-2.8.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: manta_1.4_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/manta
+        tag: '1.4'
+        path: manta/1.4/
+        docker-context: manta/1.4/
+        before_build:
+        - run_if_modified:
+            pattern: manta/1.4/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: manta_1.6.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/manta
+        tag: 1.6.0
+        path: manta/1.6.0/
+        docker-context: manta/1.6.0/
+        before_build:
+        - run_if_modified:
+            pattern: manta/1.6.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: velocyto_0.17.17_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/velocyto
+        tag: 0.17.17
+        path: velocyto/0.17.17/
+        docker-context: velocyto/0.17.17/
+        before_build:
+        - run_if_modified:
+            pattern: velocyto/0.17.17/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: speedseq_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/speedseq
+        tag: latest
+        path: speedseq/latest/
+        docker-context: speedseq/latest/
+        before_build:
+        - run_if_modified:
+            pattern: speedseq/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: svaba_1.1.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/svaba
+        tag: 1.1.0
+        path: svaba/1.1.0/
+        docker-context: svaba/1.1.0/
+        before_build:
+        - run_if_modified:
+            pattern: svaba/1.1.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: lancet_1.0.7_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/lancet
+        tag: 1.0.7
+        path: lancet/1.0.7/
+        docker-context: lancet/1.0.7/
+        before_build:
+        - run_if_modified:
+            pattern: lancet/1.0.7/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: sambamba_0.7.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/sambamba
+        tag: 0.7.1
+        path: sambamba/0.7.1/
+        docker-context: sambamba/0.7.1/
+        before_build:
+        - run_if_modified:
+            pattern: sambamba/0.7.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: sambamba_0.6.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/sambamba
+        tag: 0.6.3
+        path: sambamba/0.6.3/
+        docker-context: sambamba/0.6.3/
+        before_build:
+        - run_if_modified:
+            pattern: sambamba/0.6.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard-r_picard2.8.3-r3.3.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard-r
+        tag: picard2.8.3-r3.3.3
+        path: picard-r/picard2.8.3-r3.3.3/
+        docker-context: picard-r/picard2.8.3-r3.3.3/
+        before_build:
+        - run_if_modified:
+            pattern: picard-r/picard2.8.3-r3.3.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: picard-r_picard2.15.0-r.3.3.3_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/picard-r
+        tag: picard2.15.0-r.3.3.3
+        path: picard-r/picard2.15.0-r.3.3.3/
+        docker-context: picard-r/picard2.15.0-r.3.3.3/
+        before_build:
+        - run_if_modified:
+            pattern: picard-r/picard2.15.0-r.3.3.3/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VEP_r98_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r98
+        path: VEP/r98/
+        docker-context: VEP/r98/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r98/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VEP_r93.7_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r93.7
+        path: VEP/r93.7/
+        docker-context: VEP/r93.7/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r93.7/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VEP_r93_v2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r93_v2
+        path: VEP/r93_v2/
+        docker-context: VEP/r93_v2/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r93_v2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VEP_r94_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r94
+        path: VEP/r94/
+        docker-context: VEP/r94/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r94/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: VEP_r93_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/vep
+        tag: r93
+        path: VEP/r93/
+        docker-context: VEP/r93/
+        before_build:
+        - run_if_modified:
+            pattern: VEP/r93/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: canvas_1.11.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/canvas
+        tag: 1.11.0
+        path: canvas/1.11.0/
+        docker-context: canvas/1.11.0/
+        before_build:
+        - run_if_modified:
+            pattern: canvas/1.11.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa_0.7.15-r1140_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa
+        tag: 0.7.15-r1140
+        path: bwa/0.7.15-r1140/
+        docker-context: bwa/0.7.15-r1140/
+        before_build:
+        - run_if_modified:
+            pattern: bwa/0.7.15-r1140/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa
+        tag: latest
+        path: bwa/latest/
+        docker-context: bwa/latest/
+        before_build:
+        - run_if_modified:
+            pattern: bwa/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bwa_0.7.17-r1188_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bwa
+        tag: 0.7.17-r1188
+        path: bwa/0.7.17-r1188/
+        docker-context: bwa/0.7.17-r1188/
+        before_build:
+        - run_if_modified:
+            pattern: bwa/0.7.17-r1188/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: strelka_v2.9.10_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/strelka
+        tag: v2.9.10
+        path: strelka/v2.9.10/
+        docker-context: strelka/v2.9.10/
+        before_build:
+        - run_if_modified:
+            pattern: strelka/v2.9.10/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: star_2.7.5a_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/star
+        tag: 2.7.5a
+        path: star/2.7.5a/
+        docker-context: star/2.7.5a/
+        before_build:
+        - run_if_modified:
+            pattern: star/2.7.5a/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: star_2.6.1d_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/star
+        tag: 2.6.1d
+        path: star/2.6.1d/
+        docker-context: star/2.6.1d/
+        before_build:
+        - run_if_modified:
+            pattern: star/2.6.1d/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: star_fusion-1.5.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/star
+        tag: fusion-1.5.0
+        path: star/fusion-1.5.0/
+        docker-context: star/fusion-1.5.0/
+        before_build:
+        - run_if_modified:
+            pattern: star/fusion-1.5.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: codex2_3.8_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/codex2
+        tag: '3.8'
+        path: codex2/3.8/
+        docker-context: codex2/3.8/
+        before_build:
+        - run_if_modified:
+            pattern: codex2/3.8/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: sv2_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/sv2
+        tag: latest
+        path: sv2/latest/
+        docker-context: sv2/latest/
+        before_build:
+        - run_if_modified:
+            pattern: sv2/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: FusionCatcher_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/fusioncatcher
+        tag: latest
+        path: FusionCatcher/latest/
+        docker-context: FusionCatcher/latest/
+        before_build:
+        - run_if_modified:
+            pattern: FusionCatcher/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: controlfreec_11.5_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/controlfreec
+        tag: '11.5'
+        path: controlfreec/11.5/
+        docker-context: controlfreec/11.5/
+        before_build:
+        - run_if_modified:
+            pattern: controlfreec/11.5/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: LinkedSV_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/linkedsv
+        tag: latest
+        path: LinkedSV/latest/
+        docker-context: LinkedSV/latest/
+        before_build:
+        - run_if_modified:
+            pattern: LinkedSV/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.6_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.6
+        path: gatk/4.beta.6/
+        docker-context: gatk/4.beta.6/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.6/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.0.1.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.0.1.0
+        path: gatk/4.0.1.0/
+        docker-context: gatk/4.0.1.0/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.0.1.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.1
+        path: gatk/4.beta.1/
+        docker-context: gatk/4.beta.1/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.1.1.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.1.1.0
+        path: gatk/4.1.1.0/
+        docker-context: gatk/4.1.1.0/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.1.1.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.1-3.5_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.1-3.5
+        path: gatk/4.beta.1-3.5/
+        docker-context: gatk/4.beta.1-3.5/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.1-3.5/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.1.7.0R_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.1.7.0R
+        path: gatk/4.1.7.0R/
+        docker-context: gatk/4.1.7.0R/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.1.7.0R/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.5-tabix_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.5-tabix
+        path: gatk/4.beta.5-tabix/
+        docker-context: gatk/4.beta.5-tabix/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.5-tabix/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.0.12.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.0.12.0
+        path: gatk/4.0.12.0/
+        docker-context: gatk/4.0.12.0/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.0.12.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: latest
+        path: gatk/latest/
+        docker-context: gatk/latest/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_3.8_ubuntu_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 3.8_ubuntu
+        path: gatk/3.8_ubuntu/
+        docker-context: gatk/3.8_ubuntu/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/3.8_ubuntu/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.6-tabix_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.6-tabix
+        path: gatk/4.beta.6-tabix/
+        docker-context: gatk/4.beta.6-tabix/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.6-tabix/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.0.5.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.0.5.2
+        path: gatk/4.0.5.2/
+        docker-context: gatk/4.0.5.2/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.0.5.2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_3.5-0-g36282e4_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 3.5-0-g36282e4
+        path: gatk/3.5-0-g36282e4/
+        docker-context: gatk/3.5-0-g36282e4/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/3.5-0-g36282e4/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.beta.5_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.beta.5
+        path: gatk/4.beta.5/
+        docker-context: gatk/4.beta.5/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.beta.5/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_3.6-0-g89b7209_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 3.6-0-g89b7209
+        path: gatk/3.6-0-g89b7209/
+        docker-context: gatk/3.6-0-g89b7209/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/3.6-0-g89b7209/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_4.0.1.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: 4.0.1.2
+        path: gatk/4.0.1.2/
+        docker-context: gatk/4.0.1.2/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/4.0.1.2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: gatk_3.8_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/gatk
+        tag: '3.8'
+        path: gatk/3.8/
+        docker-context: gatk/3.8/
+        before_build:
+        - run_if_modified:
+            pattern: gatk/3.8/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: bed_tools_bedopsv2.4.36_plus_bedtools_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bed_tools
+        tag: bedopsv2.4.36_plus_bedtools
+        path: bed_tools/bedopsv2.4.36_plus_bedtools/
+        docker-context: bed_tools/bedopsv2.4.36_plus_bedtools/
+        before_build:
+        - run_if_modified:
+            pattern: bed_tools/bedopsv2.4.36_plus_bedtools/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: peddy_v0.4.7_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/peddy
+        tag: v0.4.7
+        path: peddy/v0.4.7/
+        docker-context: peddy/v0.4.7/
+        before_build:
+        - run_if_modified:
+            pattern: peddy/v0.4.7/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: peddy_v0.4.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/peddy
+        tag: v0.4.2
+        path: peddy/v0.4.2/
+        docker-context: peddy/v0.4.2/
+        before_build:
+        - run_if_modified:
+            pattern: peddy/v0.4.2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: fastqc_v0.11.9_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/fastqc
+        tag: v0.11.9
+        path: fastqc/v0.11.9/
+        docker-context: fastqc/v0.11.9/
+        before_build:
+        - run_if_modified:
+            pattern: fastqc/v0.11.9/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: samtools_1.7-11-g041220d_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/samtools
+        tag: 1.7-11-g041220d
+        path: samtools/1.7-11-g041220d/
+        docker-context: samtools/1.7-11-g041220d/
+        before_build:
+        - run_if_modified:
+            pattern: samtools/1.7-11-g041220d/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: samtools_1.9_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/samtools
+        tag: '1.9'
+        path: samtools/1.9/
+        docker-context: samtools/1.9/
+        before_build:
+        - run_if_modified:
+            pattern: samtools/1.9/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: samtools_1.6_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/samtools
+        tag: '1.6'
+        path: samtools/1.6/
+        docker-context: samtools/1.6/
+        before_build:
+        - run_if_modified:
+            pattern: samtools/1.6/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: samtools_1.3.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/samtools
+        tag: 1.3.1
+        path: samtools/1.3.1/
+        docker-context: samtools/1.3.1/
+        before_build:
+        - run_if_modified:
+            pattern: samtools/1.3.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: samtools_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/samtools
+        tag: latest
+        path: samtools/latest/
+        docker-context: samtools/latest/
+        before_build:
+        - run_if_modified:
+            pattern: samtools/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: annovar_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/annovar
+        tag: latest
+        path: annovar/latest/
+        docker-context: annovar/latest/
+        before_build:
+        - run_if_modified:
+            pattern: annovar/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: seurat_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/seurat
+        tag: latest
+        path: seurat/latest/
+        docker-context: seurat/latest/
+        before_build:
+        - run_if_modified:
+            pattern: seurat/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: annoFuse_0.90.0_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/annofuse
+        tag: 0.90.0
+        path: annoFuse/0.90.0/
+        docker-context: annoFuse/0.90.0/
+        before_build:
+        - run_if_modified:
+            pattern: annoFuse/0.90.0/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: annoFuse_0.1.8_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/annofuse
+        tag: 0.1.8
+        path: annoFuse/0.1.8/
+        docker-context: annoFuse/0.1.8/
+        before_build:
+        - run_if_modified:
+            pattern: annoFuse/0.1.8/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: pizzly_latest_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/pizzly
+        tag: latest
+        path: pizzly/latest/
+        docker-context: pizzly/latest/
+        before_build:
+        - run_if_modified:
+            pattern: pizzly/latest/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: BIC-seq2_0.7.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/bic-seq2
+        tag: 0.7.2
+        path: BIC-seq2/0.7.2/
+        docker-context: BIC-seq2/0.7.2/
+        before_build:
+        - run_if_modified:
+            pattern: BIC-seq2/0.7.2/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: freebayes_v1.3.1_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/freebayes
+        tag: v1.3.1
+        path: freebayes/v1.3.1/
+        docker-context: freebayes/v1.3.1/
+        before_build:
+        - run_if_modified:
+            pattern: freebayes/v1.3.1/Dockerfile
+            check-last-commit-on-base-branch: true
+    - docker/publish:
+        filters:
+          branches:
+            only:
+            - master
+        name: freebayes_v1.3.2_merge
+        context: dockerhub-vars
+        deploy: true
+        registry: pgc-images.sbgenomics.com
+        image: d3b-bixu/freebayes
+        tag: v1.3.2
+        path: freebayes/v1.3.2/
+        docker-context: freebayes/v1.3.2/
+        before_build:
+        - run_if_modified:
+            pattern: freebayes/v1.3.2/Dockerfile
+            check-last-commit-on-base-branch: true


### PR DESCRIPTION
Potentially return the automatic pushing. The jist of this is:
1. Diff statements continue to build but not publish the images they create
2. In a PR we'll be able to see if the build happened correct
3. When we merge into master that will trip the new merge block
4. The merge block will compare its HEAD to the previous commit HEAD~1 then build and publish the diff

Major drawback: if in a PR you made changes to a Dockerfile "A" in one commit then do a second commit changing Dockerfile "B", this merge workflow would only catch the last change and build Dockerfile "B".

Counter to the caveat: If we squash all commits at the end of PRs that will not be a problem.