### PR TITLE
💆‍♂️ swap base branch heads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ commands:
             <</ parameters.use-divergence-point >>
             <<# parameters.check-last-commit-on-base-branch >>
             if [[ "$CIRCLE_BRANCH" == "<< parameters.base-branch >>" ]]; then
-              FILES_MODIFIED=$(git diff --name-only HEAD HEAD~1 | grep -i -E '<< parameters.pattern >>')
+              FILES_MODIFIED=$(git diff --name-only HEAD~1 HEAD | grep -i -E '<< parameters.pattern >>')
             fi
             <</ parameters.check-last-commit-on-base-branch >>
           }

--- a/.circleci/make_config.py
+++ b/.circleci/make_config.py
@@ -66,7 +66,7 @@ commands:
             <</ parameters.use-divergence-point >>
             <<# parameters.check-last-commit-on-base-branch >>
             if [[ "$CIRCLE_BRANCH" == "<< parameters.base-branch >>" ]]; then
-              FILES_MODIFIED=$(git diff --name-only HEAD HEAD~1 | grep -i -E '<< parameters.pattern >>')
+              FILES_MODIFIED=$(git diff --name-only HEAD~1 HEAD | grep -i -E '<< parameters.pattern >>')
             fi
             <</ parameters.check-last-commit-on-base-branch >>
           }


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

I noticed merging https://github.com/d3b-center/bixtools/pull/92 did not result in the pushing of the created image so I investigated and found that the diff check on master was returning the old filename, which was no longer part of the circleci config. Swapping the `HEAD` and `HEAD~1` in the diff command will return the appropriate filename. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local test of the diff command

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
