### PR TITLE
🐛 svaba add ref cache script

### DIFF
--- a/svaba/1.1.0/Dockerfile
+++ b/svaba/1.1.0/Dockerfile
@@ -7,13 +7,15 @@ RUN apt update && \
     apt upgrade -y && \
     apt install -y make gcc g++ && \
     apt install -y build-essential zlib1g-dev libbz2-dev liblzma-dev ncurses-dev && \
-    apt install -y git wget bzip2
+    apt install -y git wget bzip2 libdigest-md5-perl
 
 RUN git clone --recursive -b ${SVABA_VERSION} https://github.com/walaj/svaba.git && \
     cd svaba && \
     ./configure && \
     make && \
     make install
+
+RUN wget -O /svaba/bin/seq_cache_populate.pl https://raw.githubusercontent.com/samtools/samtools/1.16/misc/seq_cache_populate.pl && chmod 777 /svaba/bin/seq_cache_populate.pl
 
 ENV PATH "$PATH:/svaba/bin"
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Svaba cannot process CRAMs unless you build a ref seq cache. This update adds that script and a perl script necessary to run it.

Part of https://github.com/d3b-center/bixu-tracker/issues/1564

Needed for https://github.com/kids-first/kf-germline-workflow/pull/22

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Builds locally 

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
