### PR TITLE
🐛  optparse now installs

### DIFF
--- a/sequenza/3.0.0/Dockerfile
+++ b/sequenza/3.0.0/Dockerfile
@@ -2,6 +2,11 @@ FROM sequenza/sequenza:3.0.0
 LABEL maintainer="Daniel Miller (millerd15@chop.edu)"
 
 USER root
-RUN install2.r falcon optparse
+RUN install2.r --error falcon getopt
+
+# Sequenza3.0.0 uses R3.5.1; optparse 1.7.1 is the last version that works with that version
+RUN wget https://cran.r-project.org/src/contrib/Archive/optparse/optparse_1.7.1.tar.gz \
+    && R CMD install optparse_1.7.1.tar.gz \
+    && rm optparse_1.7.1.tar.gz
 
 COPY Dockerfile .

--- a/sequenza/3.0.0/Dockerfile
+++ b/sequenza/3.0.0/Dockerfile
@@ -6,7 +6,7 @@ RUN install2.r --error falcon getopt
 
 # Sequenza3.0.0 uses R3.5.1; optparse 1.7.1 is the last version that works with that version
 RUN wget https://cran.r-project.org/src/contrib/Archive/optparse/optparse_1.7.1.tar.gz \
-    && R CMD install optparse_1.7.1.tar.gz \
+    && R CMD INSTALL optparse_1.7.1.tar.gz \
     && rm optparse_1.7.1.tar.gz
 
 COPY Dockerfile .


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

I guess sometime in between me making the original docker and now optparse no longer automatically installs on R 3.5.1 (they added a 3.6 requirement). To get around that I'm grabbing the previous version of optparse that does not require 3.6 and installing it manually.

Additionally it seems like install2.r needs an explicit variable `--error` otherwise it doesn't complain if something cannot be installed and will exit 0. Obviously we should be setting that to fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Built locally and loaded the libraries to make sure.

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
