### PR TITLE
🐎  update htslib;

### DIFF
--- a/octopus/0.6.3-beta/Dockerfile
+++ b/octopus/0.6.3-beta/Dockerfile
@@ -44,7 +44,7 @@ RUN cd /tmp \
     && ./b2 install
 
 # Install htslib
-ENV HTSLIB_VERSION 1.10.2
+ENV HTSLIB_VERSION 1.17
 RUN cd /tmp \
     && git clone --recursive -b $HTSLIB_VERSION https://github.com/samtools/htslib.git \
     && cd htslib \
@@ -62,6 +62,9 @@ RUN cd /tmp \
     && ./scripts/install.py --threads=$(nproc) \
     && ldconfig \
     && cp bin/octopus /usr/bin
+
+RUN cd /opt \
+    && wget https://raw.githubusercontent.com/samtools/samtools/develop/misc/seq_cache_populate.pl
 
 WORKDIR /
 


### PR DESCRIPTION
add refseq cache builder

<!--Pull Request Template-->

## Description

Something's wrong with the old version of htslib so I just bought us up to the newest release. Also I'm bringing in the samtools ref cache builder script here to speed up the cache creation (octopus is incredibly slow with it to the point where I was just handing it in).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing it here: https://cavatica.sbgenomics.com/u/d3b-bixu/dev-canine-workflow/tasks/af0f6d65-accc-4e81-97d6-6f5c04ee377b

Previous behavior is this would hang for an extended period of time before completing initialization like here in this aborted run: https://cavatica.sbgenomics.com/u/d3b-bixu/dev-canine-workflow/tasks/87f1f0f0-b3fa-4931-ac07-fde553e312c4/stats/. After an hour and a half it's still initialization with no end in side.

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
