### PR TITLE
🔧  seq cache pop to cnvnator

### DIFF
--- a/cnvnator/v0.4.1/Dockerfile
+++ b/cnvnator/v0.4.1/Dockerfile
@@ -1,50 +1,56 @@
 FROM ubuntu:18.04
 LABEL maintainer="Daniel Miller (millerd15@email.chop.edu)"
 
-RUN apt update && apt install -y --no-install-recommends \
-  ca-certificates \
-  g++ \
-  libbz2-dev \
-  libcurl3-dev \
-  libfreetype6-dev \
-  liblzma-dev \
-  libncurses5-dev \
-  libreadline-dev \
-  libpython2.7 \
-  libz-dev \
-  make \
-  python-matplotlib \
-  python-scipy \
-  python-tk \
-  curl \
- && rm -rf /var/lib/apt/lists/*
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN curl https://root.cern/download/root_v6.18.04.Linux-ubuntu18-x86_64-gcc7.4.tar.gz | \
- tar -C /opt -xzf -
+RUN apt update && apt install -y --no-install-recommends \
+    ca-certificates \
+    g++ \
+    libbz2-dev \
+    libcurl3-dev \
+    libfreetype6-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libpython2.7 \
+    libz-dev \
+    make \
+    python-matplotlib \
+    python-scipy \
+    python-tk \
+    curl \
+    libdigest-md5-file-perl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://root.cern/download/root_v6.18.04.Linux-ubuntu18-x86_64-gcc7.4.tar.gz | tar -C /opt -xzf -
 
 ENV PYTHONPATH=/opt/root/lib
 
 RUN echo '/opt/root/lib' > /etc/ld.so.conf.d/root.conf \
- && ldconfig
+    && ldconfig
 
-ENV SAMTOOLS_VERSION=1.9 \
-    CNVNATOR_VERSION=v0.4.1
+ENV SAMTOOLS_VERSION 1.10
+RUN curl -L https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 | tar -C /tmp -xjf - \
+    && cd /tmp/samtools-* \
+    && make \
+    && (cd htslib-* && make mostlyclean) \
+    && make mostlyclean \
+    && find /tmp -name test -type d -exec rm -rf {} +
 
-RUN curl -L https://github.com/samtools/samtools/releases/download/${SAMTOOLS_VERSION}/samtools-${SAMTOOLS_VERSION}.tar.bz2 | \
- tar -C /tmp -xjf - \
- && cd /tmp/samtools-* \
- && make \
- && (cd htslib-* && make mostlyclean) \
- && make mostlyclean \
- && find /tmp -name test -type d -exec rm -rf {} +
+ENV CNVNATOR_VERSION v0.4.1
+RUN curl -L https://github.com/abyzovlab/CNVnator/archive/refs/tags/${CNVNATOR_VERSION}.tar.gz | tar -C /tmp -xzf - \
+    && cd /tmp/CNVnator-* \
+    && curl -O https://raw.githubusercontent.com/abyzovlab/CNVnator/1590eedf921552e0463de43cabc3a388af5ab549/Makefile \
+    && ln -s /tmp/samtools-* samtools \
+    && ROOTSYS=/opt/root make \
+    && mv cnvnator *.py *.pl /usr/local/bin \
+    && mv pytools /usr/local/lib/python*/dist-packages \
+    && cd - \
+    && rm -rf /tmp/*
 
-RUN curl -L https://github.com/abyzovlab/CNVnator/archive/refs/tags/${CNVNATOR_VERSION}.tar.gz | \
- tar -C /tmp -xzf - \ 
- && cd /tmp/CNVnator-* \
- && curl -O https://raw.githubusercontent.com/abyzovlab/CNVnator/1590eedf921552e0463de43cabc3a388af5ab549/Makefile \ 
- && ln -s /tmp/samtools-* samtools \
- && ROOTSYS=/opt/root make \
- && mv cnvnator *.py *.pl /usr/local/bin \
- && mv pytools /usr/local/lib/python*/dist-packages \
- && cd - \
- && rm -rf /tmp/*
+RUN cd /opt \
+    && curl -OL https://raw.githubusercontent.com/samtools/samtools/develop/misc/seq_cache_populate.pl
+
+WORKDIR /
+
+COPY Dockerfile .


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Added the seq cache populate script to the image. This is necessary for not making CRAM reading such a slog for CNVnator.

Also updated the styling

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] The extract reads step with a CRAM: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/7321a0bb-61b5-482d-be20-16db4b8bd515/

This runtime is on par with what we see for BAMs: https://cavatica.sbgenomics.com/u/d3b-bixu/kf-germline-harmonization-dev/tasks/1afe79c9-9ca3-4d6d-827b-e588048336a0/

The slight difference in runtime is likely due to the runtime for the seq cache populate tool which takes ~2 minutes per run.

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
