### PR TITLE
🎉  add merge build and push workflow

### DIFF
--- a/.github/workflows/merge_build_push_diff_dockers.yml
+++ b/.github/workflows/merge_build_push_diff_dockers.yml
@@ -33,7 +33,7 @@ jobs:
           # Image names are always lowercase!
           # If no version directory exists, default to latest
           # "BANANA/1.0/Dockerfile panda/2.1/Dockerfile gatk/Dockerfile" -> [{"path":"BANANA/1.0", "image":"banana", "tag":"1.0"}, {"path": "panda/2.1", "image":"panda", "tag":"2.1"}, {"path": "gatk", "image":"gatk", "tag":"latest"}]
-          MATRIX=$(echo ${{ steps.changed-files-docker.outputs.all_changed_files }} | jq -Rr 'split(" ") | map(rtrimstr("/Dockerfile")) | map({"path": ., "image": (. | split("/")[0] | ascii_downcase), "tag": (. | split("/")[1] // "latest")}) | @json'
+          MATRIX=$(echo ${{ steps.changed-files-docker.outputs.all_changed_files }} | jq -Rr 'split(" ") | map(rtrimstr("/Dockerfile")) | map({"path": ., "image": (. | split("/")[0] | ascii_downcase), "tag": (. | split("/")[1] // "latest")}) | @json')
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
   build-dockerfiles:
     name: Build ${{ matrix.image }}:${{ matrix.tag }}

--- a/.github/workflows/merge_build_push_diff_dockers.yml
+++ b/.github/workflows/merge_build_push_diff_dockers.yml
@@ -1,0 +1,62 @@
+name: Latest Merged Dockerfile Build and Push
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+    paths:
+      - '**/Dockerfile'
+
+jobs:
+  changed-dockerfiles:
+    name: Get Changed Dockerfiles Matrix
+    runs-on: ubuntu-22.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: checkout
+        uses: actions/checkout@v3
+        name: Checkout Repo
+        with:
+          fetch-depth: 0
+      - id: changed-files-docker
+        uses: tj-actions/changed-files@v35
+        name: Get Changed Dockerfiles
+        with:
+          files: |
+            **/Dockerfile
+      - id: set-matrix
+        name: Changed Dockerfiles String to Matrix
+        run: |
+          # From a space separated list of files, split by space, and set grandparent/parent dirnames as image/tag
+          # Image names are always lowercase!
+          # If no version directory exists, default to latest
+          # "BANANA/1.0/Dockerfile panda/2.1/Dockerfile gatk/Dockerfile" -> [{"path":"BANANA/1.0", "image":"banana", "tag":"1.0"}, {"path": "panda/2.1", "image":"panda", "tag":"2.1"}, {"path": "gatk", "image":"gatk", "tag":"latest"}]
+          MATRIX=$(echo ${{ steps.changed-files-docker.outputs.all_changed_files }} | jq -Rr 'split(" ") | map(rtrimstr("/Dockerfile")) | map({"path": ., "image": (. | split("/")[0] | ascii_downcase), "tag": (. | split("/")[1] // "latest")}) | @json'
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+  build-dockerfiles:
+    name: Build ${{ matrix.image }}:${{ matrix.tag }}
+    needs: changed-dockerfiles
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.changed-dockerfiles.outputs.matrix) }}
+    steps:
+      - id: cavatica-login
+        name: Login to Cavatica
+        uses: docker/login-action@v2
+        with:
+          registry: pgc-images.sbgenomics.com
+          username: ${{ secrets.CAVATICA_USERNAME }}
+          password: ${{ secrets.CAVATICA_TOKEN }}
+      - id: docker-buildx-setup
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - id: test-build
+        name: Test Build Dockerfile
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          context: "{{defaultContext}}:${{ matrix.path }}"
+          tags: pgc-images.sbgenomics.com/${{ secrets.CAVATICA_USERNAME }}/${{ matrix.image }}:${{ matrix.tag }}


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Adds github action to build and push changed dockerfiles to cavatica whenever a push/merge happens on the main/master branch affecting any dockerfiles.

Part of https://github.com/d3b-center/bixu-tracker/issues/1885
Closes https://github.com/d3b-center/bixu-tracker/issues/1833

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] I guess we'll wait and see whenever we add our next docker

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
