### PR TITLE
🐛  rollback samtools

### DIFF
--- a/stranded/1.1.0/Dockerfile
+++ b/stranded/1.1.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM staphb/samtools:1.19
+FROM staphb/samtools:1.17
 
 RUN apt update && apt install -y curl python-is-python3 python3-pip git
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

For some reason newer versions of the samtools docker screw with the program's ability to find the RSeQC install. Probably related to the python version, but I don't know how to test that. I decided to just rollback the samtools version so we can move forward with this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing with a person docker here: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/bfe442cc-a094-4b09-9811-2c923b2c11b0/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
