### PR TITLE
🤖  disable docker push provenance

### DIFF
--- a/.github/workflows/merge_build_push_diff_dockers.yml
+++ b/.github/workflows/merge_build_push_diff_dockers.yml
@@ -58,5 +58,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          provenance: false
           context: "{{defaultContext}}:${{ matrix.path }}"
           tags: pgc-images.sbgenomics.com/${{ secrets.CAVATICA_USERNAME }}/${{ matrix.image }}:${{ matrix.tag }}


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Turn off docker push provenance. According to Cavatica and the action release notes, disabling this should result in images being properly displayed on the registry.

Closes https://d3b.atlassian.net/browse/BIXU-3682

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Doing it live I guess

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
