### PR TITLE
🎉  add docker for plotting GATK hardfilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ t1k|v1.0.5|docker pull pgc-images.sbgenomics.com/d3b-bixu/t1k:v1.0.5
 THetA2|0.7.0|docker pull pgc-images.sbgenomics.com/d3b-bixu/theta2:0.7.0
 THetA2|0.7.1|docker pull pgc-images.sbgenomics.com/d3b-bixu/theta2:0.7.1
 tidyverse|3.6.1-canine-util|docker pull pgc-images.sbgenomics.com/d3b-bixu/tidyverse:3.6.1-canine-util
+tidyverse|4.4.2-gatk-plotter|docker pull pgc-images.sbgenomics.com/d3b-bixu/tidyverse:4.4.2-gatk-plotter
 toolkit_immune_deconvolution|1.0.0|docker pull pgc-images.sbgenomics.com/d3b-bixu/toolkit_immune_deconvolution:1.0.0
 toolkit_immune_deconvolution|1.1.0|docker pull pgc-images.sbgenomics.com/d3b-bixu/toolkit_immune_deconvolution:1.1.0
 toolkit_python|3.0.0|docker pull pgc-images.sbgenomics.com/d3b-bixu/toolkit_python:3.0.0

--- a/tidyverse/4.4.2-gatk-plotter/Dockerfile
+++ b/tidyverse/4.4.2-gatk-plotter/Dockerfile
@@ -1,0 +1,8 @@
+FROM rocker/tidyverse:4.4.2
+
+LABEL maintainer="Daniel Miller <dmiller15@chop.edu>"
+LABEL description="tidyverse image with gridExtras for generating GATK HardFilteirng charts"
+
+RUN install2.r gridExtra
+
+COPY Dockerfile .


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

New docker for plotting density charts of annotations in Hard Filtered genotyped VCFs. Important for retrospective analysis of hard filtering. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Built and tested locally

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
